### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
     "coverage": "npm test --coverage && istanbul check-coverage --lines 100 --function 100 --statements 100 --branches 100"
   },
   "dependencies": {
-    "argsarray": "0.0.1",
     "inherits": "^2.0.3",
-    "lodash.pick": "^4.0.0",
     "ndjson": "^1.4.3",
     "pouch-stream": "^0.4.0",
     "pouchdb-promise": "^6.0.4",


### PR DESCRIPTION
While running a dependencies vulnerability audit on Budibase monorepo I realise we have a vulnerability brought by lodash.pick. This library is not used, so cleaning it up will clean up this vulnerability alert